### PR TITLE
change so that plot script is cloned from the organisations fork

### DIFF
--- a/Project_clone/Tools/Admixture/plot_admixture.sh
+++ b/Project_clone/Tools/Admixture/plot_admixture.sh
@@ -2,7 +2,7 @@ module load bioinfo-tools
 module load R_packages
 
 # Download script for plotting:
-wget https://raw.githubusercontent.com/speciationgenomics/scripts/master/plotADMIXTURE.r
+wget https://raw.githubusercontent.com/CGI-NRM/scripts_fork/master/plotADMIXTURE.r
 
 # Run script, make sure that you have prepared a popfile.txt corresponding to "-l":
 Rscript ./plotADMIXTURE.r -p pphocoena_1 -i popfile.txt -k 5 -l population1,population2


### PR DESCRIPTION
I have forked the original repository of the plotting script (speciationgenomics/scripts) so that we can download it from our own organisation when running the script in order to have more stability.